### PR TITLE
Switch basemap in OlMapService

### DIFF
--- a/service/openlayermap/ol-map.service.ts
+++ b/service/openlayermap/ol-map.service.ts
@@ -349,5 +349,13 @@ export class OlMapService {
   public updateSize() {
     this.olMapObject.updateSize();
   }
+  
+  /**
+   * Change the OL Map's basemap
+   * @param baseMap the basemap's ID value (string)
+   */
+  public switchBaseMap(baseMap: string) {
+    this.olMapObject.switchBaseMap(baseMap);
+  }
 
 }


### PR DESCRIPTION
Added a method in OlMapService to call the associated OlMapObject's switchBaseMap method.