### PR TITLE
Added setLayerSourceParam() method

### DIFF
--- a/service/openlayermap/ol-map-object.ts
+++ b/service/openlayermap/ol-map-object.ts
@@ -239,7 +239,22 @@ export class OlMapObject {
       }
     }
   }
-
+  
+  /**
+   * Set or modify a layer's source parameter
+   * @param param the source parameter name
+   * @param value the new source parameter value
+   */
+  public setLayerSourceParam(layerId: string, param: string, value: any) {
+	const activelayers = this.getLayerById(layerId);
+    if (activelayers) {
+      activelayers.forEach(layer => {
+		layer.getSource().updateParams({[param]: value});
+      });
+      this.renderStatusService.resetLayer(layerId);
+    }
+  }
+  
   /**
   * Method for drawing a polygon shape on the map. e.g selecting a polygon bounding box on the map
   * @returns a observable object that triggers an event when the user complete the drawing

--- a/service/openlayermap/ol-map.service.ts
+++ b/service/openlayermap/ol-map.service.ts
@@ -271,7 +271,18 @@ export class OlMapService {
   public getAddLayerSubject(): Subject<LayerModel> {
     return this.addLayerSubject;
   }
-
+  
+  /**
+   * Set or modify a layer's source parameter.
+   * For example, to change the time position of a WMS layer:
+   *    setLayerSourceParam('TIME', '2003-08-08T00:00:00.000Z');
+   * @param param the source parameter name
+   * @param value the new source parameter value
+   */
+  public setLayerSourceParam(layerId: string, param: string, value: any) {
+	this.olMapObject.setLayerSourceParam(layerId, param, value);
+  }
+  
   /**
    * Fit the map to the extent that is provided
    * @param extent An array of numbers representing an extent: [minx, miny, maxx, maxy]


### PR DESCRIPTION
Added a method to set/modify a layer's source parameters. Necessary to be able to modify a WMS layer's time position (for example). E.g:

olMapService.setLayerSourceParam('some_layer', 'TIME', '1991-03-20T00:00:00.000Z');