### PR TITLE
AUS-3411: only show relevant service providers in WFS pop up

### DIFF
--- a/service/openlayermap/ol-map.service.ts
+++ b/service/openlayermap/ol-map.service.ts
@@ -76,14 +76,11 @@ export class OlMapService {
                            if (!me.layerHandlerService.containsWMS(layerModel)) {
                              continue;
                            }
-                           for (const cswRecord of layerModel.cswRecords) {
-                               for (const bbox of cswRecord.geographicElements) {
-                                   const poly = bboxPolygon([bbox.eastBoundLongitude, bbox.southBoundLatitude, bbox.westBoundLongitude, bbox.northBoundLatitude]);
-                                   if (inside(clickPoint, poly) && !clickedLayerList.includes(activeLayer)) {
-                                     // Add to list of clicked layers
-                                     clickedLayerList.push(activeLayer);
-                                   }
-                               }
+                           const bbox = activeLayer.onlineResource.geographicElements[0];
+                           const poly = bboxPolygon([bbox.eastBoundLongitude, bbox.southBoundLatitude, bbox.westBoundLongitude, bbox.northBoundLatitude]);
+                           if (inside(clickPoint, poly) && !clickedLayerList.includes(activeLayer)) {
+                             // Add to list of clicked layers
+                             clickedLayerList.push(activeLayer);
                            }
                        }
                    }


### PR DESCRIPTION
The clickHandler bit wrongly loops through all the CSW records related to the layer, and matches it with the click point, so it always returns true (because there will always be 1 that matches e.g. it's comparing activeLayer for NSW and matches it with CSW record for WA).

That's why when I click on WA for old ER:Mine layer, it gives me an error with GSNSW in the pop-up.
Usually, the GSNSW info wouldn't appear as the controller part that queries GetFeatureInfo would return nothing for that point.
But, there's something wrong with GSNSW  and VIC er:Mine layer (that's why NSW and VIC are not appearing on the map). And this error is then captured and passed on in the WMS pop-up for WA. 
So there are 2 things going wrong here.. I will investigate why NSW and VIC aren't showing on another ticket.

In summary, the click should only care about CSW record relating to the location. 