### PR TITLE
Update deprecated @turf/inside package with @turf/boolean-point-in-po…

### DIFF
--- a/service/openlayermap/ol-map.service.ts
+++ b/service/openlayermap/ol-map.service.ts
@@ -7,7 +7,7 @@ import olFeature from 'ol/Feature';
 import * as olProj from 'ol/proj';
 import {BehaviorSubject,  Subject } from 'rxjs';
 import { point } from '@turf/helpers';
-import inside from '@turf/inside';
+import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
 import bboxPolygon from '@turf/bbox-polygon';
 import { BBox } from '@turf/helpers';
 import { LayerModel } from '../../model/data/layer.model';
@@ -78,7 +78,7 @@ export class OlMapService {
                            }
                            const bbox = activeLayer.onlineResource.geographicElements[0];
                            const poly = bboxPolygon([bbox.eastBoundLongitude, bbox.southBoundLatitude, bbox.westBoundLongitude, bbox.northBoundLatitude]);
-                           if (inside(clickPoint, poly) && !clickedLayerList.includes(activeLayer)) {
+                           if (booleanPointInPolygon(clickPoint, poly) && !clickedLayerList.includes(activeLayer)) {
                              // Add to list of clicked layers
                              clickedLayerList.push(activeLayer);
                            }


### PR DESCRIPTION
Updated deprecated @turf/inside package with @turf/boolean-point-in-polygon.

This will mean replacing all instances of @turf/inside. Just change the package in package.json, and any import with the new method and then replace the inside method itself. E.g:

**package.json:**

Replace:
`"@turf/inside": "^x.x.x",`

With: 

`"@turf/boolean-point-in-polygon": "^6.0.1",`

**your.component.ts:**

Replace (for example):

```
import inside from "@turf/inside"
...
inside(point(event.coordinate), poly)
```

With:

```
import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
...
booleanPointInPolygon(point(event.coordinate), poly)
```